### PR TITLE
Improve videos and screenshots

### DIFF
--- a/app/cypress.config.ts
+++ b/app/cypress.config.ts
@@ -11,8 +11,8 @@ export default defineConfig({
     baseUrl: 'http://localhost:3000/',
     supportFile: 'cypress/support/e2e.ts',
     // the screenshots dont work well with larger screens
-    viewportWidth: 1368,
-    viewportHeight: 768,
+    viewportWidth: 1900,
+    viewportHeight: 1200,
     setupNodeEvents(on, config) {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       require('@cypress/code-coverage/task')(on, config);

--- a/app/cypress/e2e/index.cy.ts
+++ b/app/cypress/e2e/index.cy.ts
@@ -7,6 +7,9 @@ describe('landing', () => {
   it('should render', () => {
     cy.visitAndWaitFor(HomeRoute, 'index');
     cy.get('[data-cy=product-tile]').should('have.lengthOf.at.least', 10);
+    cy.get('img').should(($imgs) =>
+      $imgs.map((i, img) => expect(img.naturalWidth).to.be.greaterThan(0))
+    );
     cy.runnerScreenShot();
   });
 });

--- a/app/cypress/e2e/index.cy.ts
+++ b/app/cypress/e2e/index.cy.ts
@@ -7,6 +7,6 @@ describe('landing', () => {
   it('should render', () => {
     cy.visitAndWaitFor(HomeRoute, 'index');
     cy.get('[data-cy=product-tile]').should('have.lengthOf.at.least', 10);
-    cy.screenshot();
+    cy.runnerScreenShot();
   });
 });

--- a/app/cypress/e2e/productdetails.cy.ts
+++ b/app/cypress/e2e/productdetails.cy.ts
@@ -10,7 +10,7 @@ describe('the product details', () => {
 
     cy.location('pathname').should('contain', ProductDetailsRoute);
     cy.get('[data-cy=product-detail]').should('have.length', 1);
-    cy.screenshot();
+    cy.runnerScreenShot();
   });
 
   it('can be left by clicking on the logo', () => {

--- a/app/cypress/support/commands.ts
+++ b/app/cypress/support/commands.ts
@@ -9,3 +9,7 @@ Cypress.Commands.add('visitAndWaitFor', (pathname, testId) => {
   cy.visit(pathname);
   cy.findByTestId(testId).should('exist').and('be.visible');
 });
+
+Cypress.Commands.add('runnerScreenShot', () => {
+  cy.screenshot({ capture: 'runner' });
+});

--- a/app/cypress/support/custom-commands.d.ts
+++ b/app/cypress/support/custom-commands.d.ts
@@ -13,5 +13,12 @@ declare namespace Cypress {
      * @example cy.visitAndWaitFor('/contact', 'contact_page_hero_banner')
      */
     visitAndWaitFor(pathname: string, testId: string): void;
+
+    /**
+     * Because the screenshots don't look good on the other options,
+     * this command captures a screenshot with the option
+     * { capture: 'runner' }
+     */
+    runnerScreenShot(): void;
   }
 }


### PR DESCRIPTION
Now we render the screenshots with a 1900x1200 viewport, which looks a lot better:

![landing -- should render](https://user-images.githubusercontent.com/1506818/227771745-2eead2ff-6a31-4392-908a-852971fad6f3.png)


Now the successful tests are on the right, but i think this is ok.