### PR TITLE
app: downgrade sharp to 0.31.0

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -24,7 +24,7 @@
         "next": "13.2.4",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "sharp": "0.32.0",
+        "sharp": "0.31.0",
         "zod": "3.21.4"
       },
       "devDependencies": {
@@ -11159,9 +11159,9 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.0.0.tgz",
-      "integrity": "sha512-GyHvgPvUXBvAkXa0YvYnhilSB1A+FRYMpIVggKzPZqdaZfevZOuzfWzyvgzOwRLHBeo/MMswmJFsrNF4Nw1pmA=="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -12861,16 +12861,16 @@
       "peer": true
     },
     "node_modules/sharp": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.0.tgz",
-      "integrity": "sha512-yLAypVcqj1toSAqRSwbs86nEzfyZVDYqjuUX8grhFpeij0DDNagKJXELS/auegDBRDg1XBtELdOGfo2X1cCpeA==",
+      "version": "0.31.0",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.31.0.tgz",
+      "integrity": "sha512-ft96f8WzGxavg0rkLpMw90MTPMUZDyf0tHjPPh8Ob59xt6KzX8EqtotcqZGUm7kwqpX2pmYiyYX2LL0IZ/FDEw==",
       "hasInstallScript": true,
       "dependencies": {
         "color": "^4.2.3",
         "detect-libc": "^2.0.1",
-        "node-addon-api": "^6.0.0",
+        "node-addon-api": "^5.0.0",
         "prebuild-install": "^7.1.1",
-        "semver": "^7.3.8",
+        "semver": "^7.3.7",
         "simple-get": "^4.0.1",
         "tar-fs": "^2.1.1",
         "tunnel-agent": "^0.6.0"

--- a/app/package.json
+++ b/app/package.json
@@ -36,7 +36,7 @@
     "next": "13.2.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "sharp": "0.32.0",
+    "sharp": "0.31.0",
     "zod": "3.21.4"
   },
   "devDependencies": {


### PR DESCRIPTION
On my ubuntu 22 with newest docker installation, i had the following error: #0 32.65 info  - Collecting page data...
#0 37.09
#0 37.09 > Build error occurred
#0 37.09 [Error: ENOENT: no such file or directory, copyfile '/app/node_modules/sharp/build/Release/sharp-linux-x64.node' -> '/app/.next/standalone/node_modules/sharp/build/Release/sharp-linux-x64.node'] {
#0 37.09   errno: -2,
#0 37.09   code: 'ENOENT',
#0 37.09   syscall: 'copyfile',
#0 37.09   path: '/app/node_modules/sharp/build/Release/sharp-linux-x64.node',
#0 37.09   dest: '/app/.next/standalone/node_modules/sharp/build/Release/sharp-linux-x64.node'
#0 37.09 }

worked fine in ci though....???